### PR TITLE
Add settings to set the default marker scale and opacity

### DIFF
--- a/addons/markers/functions/fnc_initializeUI.sqf
+++ b/addons/markers/functions/fnc_initializeUI.sqf
@@ -131,8 +131,8 @@ private _reinforcedCbCtrl = _mainDisplay displayCtrl REINFORCED_CHECKBOX;
 private _reducedCbCtrl = _mainDisplay displayCtrl REDUCED_CHECKBOX;
 private _hqCbCtrl = _mainDisplay displayCtrl HQ_CHECKBOX;
 
-private _markerScale = MARKER_SCALE;
-private _markerAlpha = MARKER_ALPHA;
+private _markerScale = GVAR(defaultMarkerScale); // CBA Setting
+private _markerAlpha = GVAR(defaultMarkerAlpha); // CBA Setting
 
 // Operational Condition
 private _damagedCbCtrl = _mainDisplay displayCtrl DAMAGED_CHECKBOX;

--- a/addons/markers/functions/fnc_onAlphaSliderMouseButtonUp.sqf
+++ b/addons/markers/functions/fnc_onAlphaSliderMouseButtonUp.sqf
@@ -22,5 +22,5 @@ params ["_ctrl", "_button"];
 // Must be RMB
 CHECK(_button isNotEqualTo 1);
 
-_ctrl sliderSetPosition MARKER_ALPHA;
-[_ctrl, MARKER_ALPHA] call FUNC(onAlphaSliderPosChanged);
+_ctrl sliderSetPosition GVAR(defaultMarkerAlpha);
+[_ctrl, GVAR(defaultMarkerAlpha)] call FUNC(onAlphaSliderPosChanged);

--- a/addons/markers/functions/fnc_onScaleSliderMouseButtonUp.sqf
+++ b/addons/markers/functions/fnc_onScaleSliderMouseButtonUp.sqf
@@ -22,5 +22,5 @@ params ["_ctrl", "_button"];
 // Must be RMB
 CHECK(_button isNotEqualTo 1);
 
-_ctrl sliderSetPosition MARKER_SCALE;
-[_ctrl, MARKER_SCALE] call FUNC(onScaleSliderPosChanged);
+_ctrl sliderSetPosition GVAR(defaultMarkerScale);
+[_ctrl, GVAR(defaultMarkerScale)] call FUNC(onScaleSliderPosChanged);

--- a/addons/markers/initSettings.hpp
+++ b/addons/markers/initSettings.hpp
@@ -8,7 +8,7 @@
     {
         GVAR(lastSelection) = [];
     }
-] call CBA_settings_fnc_init;
+] call CBA_fnc_addSetting;
 
 [
     QGVAR(useVanillaColors),
@@ -18,7 +18,7 @@
     false,
     0,
     {}
-] call CBA_settings_fnc_init;
+] call CBA_fnc_addSetting;
 
 [
     QGVAR(displayShortDTG),
@@ -28,4 +28,4 @@
     true,
     2,
     {}
-] call CBA_settings_fnc_init;
+] call CBA_fnc_addSetting;

--- a/addons/markers/initSettings.hpp
+++ b/addons/markers/initSettings.hpp
@@ -29,3 +29,23 @@
     2,
     {}
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(defaultMarkerScale),
+    "SLIDER",
+    [LLSTRING(cba_settings_default_marker_scale), LLSTRING(cba_settings_default_marker_scale_tooltip)],
+    LLSTRING(cba_category_name),
+    [MIN_SCALE, MAX_SCALE, MARKER_SCALE],
+    0,
+    {}
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(defaultMarkerAlpha),
+    "SLIDER",
+    [LLSTRING(cba_settings_default_marker_alpha), LLSTRING(cba_settings_default_marker_alpha_tooltip)],
+    LLSTRING(cba_category_name),
+    [MIN_ALPHA, MAX_ALPHA, MARKER_ALPHA],
+    0,
+    {}
+] call CBA_fnc_addSetting;

--- a/addons/markers/stringtable.xml
+++ b/addons/markers/stringtable.xml
@@ -1037,6 +1037,22 @@
                 <Original>Use the short Date-Time Group display format (HHMMZ) as default.</Original>
                 <German>Nutze das kurze Datum/Zeit-Gruppe Anzeigeformat (HHMMZ) standardmäßig.</German>
             </Key>
+            <Key ID="str_mts_markers_cba_settings_default_marker_scale">
+                <Original>Default marker scale</Original>
+                <German>Standard Marker-Skalierung</German>
+            </Key>
+            <Key ID="str_mts_markers_cba_settings_default_marker_scale_tooltip">
+                <Original>Sets the initial marker scale in the UI.</Original>
+                <German>Setzt die initiale Marker-Skalierung in der Benutzeroberfläche.</German>
+            </Key>
+            <Key ID="str_mts_markers_cba_settings_default_marker_alpha">
+                <Original>Default marker opacity</Original>
+                <German>Standard Marker-Deckkraft</German>
+            </Key>
+            <Key ID="str_mts_markers_cba_settings_default_marker_alpha_tooltip">
+                <Original>Sets the initial marker opacity in the UI.</Original>
+                <German>Setzt die initiale Marker-Deckkraft in der Benutzeroberfläche.</German>
+            </Key>
         </Container>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Use public API for CBA settings
- Add settings to set the default marker scale and opacity
- Close #103 