### PR TITLE
Add broadcast channel for scripted global marker

### DIFF
--- a/addons/markers/XEH_PREP.hpp
+++ b/addons/markers/XEH_PREP.hpp
@@ -30,6 +30,7 @@ PREP(identityButtonsAction);
 PREP(initializeDTGUI);
 PREP(initializeUI);
 PREP(isMtsMarker);
+PREP(isValidBroadcastChannel);
 PREP(loadPreset);
 PREP(moveMarkerInProgress);
 PREP(moveMarkerInProgress3DEN);

--- a/addons/markers/functions/fnc_createMarker.sqf
+++ b/addons/markers/functions/fnc_createMarker.sqf
@@ -7,7 +7,9 @@
  *
  *  Parameter(s):
  *      0: ARRAY - Position where the marker will be placed.
- *      1: NUMBER - Channel ID where marker is broadcasted. (Check "currentChannel" command for channel ID (-1 up to 5 are supported); Use -1 for local creation)
+ *      1: NUMBER - Channel ID where marker is broadcasted.
+ *          Check "currentChannel" command for channel ID (-1 up to 5 are supported)
+ *          Use -1 for local creation and -10 for global without channel alpha.
  *      2: BOOLEAN - Is the marker editable.
  *      3: ARRAY - The marker configuration.
  *          0: ARRAY - Frameshape of the marker.
@@ -50,7 +52,7 @@ params [
     ["_alpha", MARKER_ALPHA, [0]]
 ];
 
-CHECKRET(((_broadcastChannel > 5) || (_broadcastChannel < -1)),ERROR("Channel ID not supported"));
+CHECKRET(!([_broadcastChannel] call FUNC(isValidBroadcastChannel)),ERROR("Channel ID not supported."));
 
 //get player UID
 private _playerUID = getPlayerUID player;

--- a/addons/markers/functions/fnc_deleteMarker.sqf
+++ b/addons/markers/functions/fnc_deleteMarker.sqf
@@ -23,7 +23,7 @@ CHECKRET(_namePrefix isEqualTo "",ERROR("No marker prefix"); false);
 //get channel ID from marker prefix
 private _broadcastChannel = [_namePrefix] call FUNC(getBroadcastChannel);
 
-CHECKRET(((_broadcastChannel > 5) || (_broadcastChannel < -1)),ERROR("Invalid marker prefix. No MTS marker"); false);
+CHECKRET(!([_broadcastChannel] call FUNC(isValidBroadcastChannel)),ERROR("Invalid marker prefix. No MTS marker"); false);
 
 //broadcast marker depending on channel ID
 [_namePrefix] remoteExecCall [QFUNC(deleteMarkerLocal), ([_broadcastChannel] call FUNC(getBroadcastTargets)), true];

--- a/addons/markers/functions/fnc_generateUniquePrefix.sqf
+++ b/addons/markers/functions/fnc_generateUniquePrefix.sqf
@@ -21,7 +21,7 @@
 params [["_editable", true, [true]], ["_broadcastChannel", -1, [0]], ["_playerUID", "0", [""]]];
 private ["_namePrefix"];
 
-CHECKRET(((_broadcastChannel > 5) || (_broadcastChannel < -1)),ERROR("Channel ID not supported"));
+CHECKRET(!([_broadcastChannel] call FUNC(isValidBroadcastChannel)),ERROR("Channel ID not supported"));
 
 //generate unique marker name & return
 private _uniqueName = false;

--- a/addons/markers/functions/fnc_generateUniquePrefix.sqf
+++ b/addons/markers/functions/fnc_generateUniquePrefix.sqf
@@ -7,7 +7,9 @@
  *
  *  Parameter(s):
  *      0: BOOLEAN - Is marker editable.
- *      1: NUMBER - Channel ID where marker is broadcasted. (Check "currentChannel" command for channel ID; Use -1 for local creation)
+ *      1: NUMBER - Channel ID where marker is broadcasted.
+ *          Check "currentChannel" command for channel ID (-1 up to 5 are supported)
+ *          Use -1 for local creation and -10 for global without channel alpha.
  *      2: STRING - Player UID.
  *
  *  Returns:
@@ -22,6 +24,12 @@ params [["_editable", true, [true]], ["_broadcastChannel", -1, [0]], ["_playerUI
 private ["_namePrefix"];
 
 CHECKRET(!([_broadcastChannel] call FUNC(isValidBroadcastChannel)),ERROR("Channel ID not supported"));
+
+// Special case handling for -10 global without alpha.
+// Setting -10 at the end does not work, the marker must end with a string that parses to -1
+if (_broadcastChannel isEqualTo BC_SCRIPTED_GLOBAL) then {
+    _broadcastChannel = BC_SCRIPTED_GLOBAL_MARKER_SUFFIX;
+};
 
 //generate unique marker name & return
 private _uniqueName = false;

--- a/addons/markers/functions/fnc_getBroadcastChannel.sqf
+++ b/addons/markers/functions/fnc_getBroadcastChannel.sqf
@@ -22,10 +22,10 @@ CHECKRET(_namePrefix isEqualTo "",ERROR("No marker prefix"));
 
 switch ([_namePrefix] call FUNC(isMtsMarker)) do {
      case 1: {
-         parseNumber ((_namePrefix splitString "/") param [2, "-1"])
+        parseNumber ((_namePrefix splitString "/") param [2, "-1"])
      };
      case 2: {
-         parseNumber ((_namePrefix splitString "~") param [1, "-1"])
+        parseNumber ((_namePrefix splitString "~") param [1, "-1"])
      };
      default {
         -2

--- a/addons/markers/functions/fnc_getBroadcastChannel.sqf
+++ b/addons/markers/functions/fnc_getBroadcastChannel.sqf
@@ -20,14 +20,19 @@ params [["_namePrefix", "", [""]]];
 
 CHECKRET(_namePrefix isEqualTo "",ERROR("No marker prefix"));
 
-switch ([_namePrefix] call FUNC(isMtsMarker)) do {
-     case 1: {
-        parseNumber ((_namePrefix splitString "/") param [2, "-1"])
-     };
-     case 2: {
-        parseNumber ((_namePrefix splitString "~") param [1, "-1"])
-     };
-     default {
-        -2
-     };
- };
+private _channelStr = switch ([_namePrefix] call FUNC(isMtsMarker)) do {
+    case 1: {
+        (_namePrefix splitString "/") param [2, ""]
+    };
+    case 2: {
+        (_namePrefix splitString "~") param [1, ""]
+    };
+    default {
+        ""
+    };
+};
+
+if (_channelStr isEqualTo "") exitWith {BC_INVALID};
+if (_channelStr isEqualTo BC_SCRIPTED_GLOBAL_MARKER_SUFFIX) exitWith {BC_SCRIPTED_GLOBAL};
+
+parseNumber _channelStr

--- a/addons/markers/functions/fnc_getBroadcastTargets.sqf
+++ b/addons/markers/functions/fnc_getBroadcastTargets.sqf
@@ -22,7 +22,7 @@
 params [["_broadcastChannel", -1, [0]]];
 
 switch (_broadcastChannel) do {
-    case -10; // global creation without channel alpha
+    case BC_SCRIPTED_GLOBAL; // global creation without channel alpha
     case 0: {
         0
     };

--- a/addons/markers/functions/fnc_getBroadcastTargets.sqf
+++ b/addons/markers/functions/fnc_getBroadcastTargets.sqf
@@ -6,7 +6,10 @@
  *      Returnes broadcast targets for remoteExec based on the broadcast channel.
  *
  *  Parameter(s):
- *      0: NUMBER - Broadcast channel. (Check "currentChannel" command for channel ID; Use -1 for local creation)
+ *      0: NUMBER - Broadcast channel. (
+ *          Check "currentChannel" command for channel ID.
+ *          Use -1  for local creation without channel alpha.
+ *          Use -10 for global creation without channel alpha.
  *
  *  Returns:
  *      ARRAY/SIDE/OBJECT - Broadcast targets. Array of players, player side or player object.
@@ -19,6 +22,7 @@
 params [["_broadcastChannel", -1, [0]]];
 
 switch (_broadcastChannel) do {
+    case -10; // global creation without channel alpha
     case 0: {
         0
     };

--- a/addons/markers/functions/fnc_initializeUI.sqf
+++ b/addons/markers/functions/fnc_initializeUI.sqf
@@ -8,7 +8,7 @@
  *      Adds Combobox selections and pictures.
  *
  *  Parameter(s):
- *      0: DISPLAY - Display on which the dialog should apear. (Check mts_markers_fnc_getDisplay)
+ *      0: DISPLAY - Display on which the dialog should appear. (Check mts_markers_fnc_getDisplay)
  *      1: ARRAY - Mouse position on map. (Not needed if parameter 2 is given e.g. nil)
  *      2: STRING - Unique marker prefix for editing set marker. (Not needed if dialog should open with default settings)
  *
@@ -96,14 +96,15 @@ _directionCtrl lbSetCurSel 0;
 
 // Channel
 private _channelCtrl = _mainDisplay displayCtrl CHANNEL_DROPDOWN;
+private _channelTxtCtrl = _mainDisplay displayCtrl CHANNEL_TXT;
 if (!isMultiplayer || is3DEN) then {
     //hide channel dropdown in singleplayer and 3DEN editor
     _channelCtrl ctrlShow false;
-    (_mainDisplay displayCtrl CHANNEL_TXT) ctrlShow false;
+    _channelTxtCtrl ctrlShow false;
 } else {
     //fill the channel combobox & select current channel
     _channelCtrl ctrlShow true;
-    (_mainDisplay displayCtrl CHANNEL_TXT) ctrlShow true;
+    _channelTxtCtrl ctrlShow true;
 
     private _channelDropdownArray = [
         ["str_channel_global", 0, "colorGlobalChannel"],
@@ -182,7 +183,7 @@ if ((_namePrefix isEqualTo "") && !GVAR(saveLastSelection)) then {
 } else {
     //when editing marker or saving of last selection is enabled
     private _markerParameter = [];
-    private _broadcastChannel = -1;
+    private _broadcastChannel = BC_SCRIPTED_LOCAL;
     if (GVAR(saveLastSelection) && (_namePrefix isEqualTo "")) then {
         if (GVAR(lastSelection) isEqualTo []) then {
             _markerParameter set [0, ["blu", false]];
@@ -201,7 +202,7 @@ if ((_namePrefix isEqualTo "") && !GVAR(saveLastSelection)) then {
         //get marker family parameter & information from namespace
         private _markerInformation = GVAR(namespace) getVariable [_namePrefix, [[]]];
         _markerParameter = _markerInformation param [1, [], [[]]];
-        _broadcastChannel = _markerInformation param [2, -1, [0]];
+        _broadcastChannel = _markerInformation param [2, BC_SCRIPTED_LOCAL, [0]];
         _markerScale = [_namePrefix] call FUNC(getMarkerScale);
         _markerAlpha = [_namePrefix] call FUNC(getMarkerAlpha);
 
@@ -209,7 +210,12 @@ if ((_namePrefix isEqualTo "") && !GVAR(saveLastSelection)) then {
     };
     CHECK(_markerParameter isEqualTo []);
 
-    //select the original broadcast channel in dropdown
+    if (isMultiplayer && _broadcastChannel < 0) then {
+        // Set default fallback channel to group when editing special scripted marker in MP.
+        _broadcastChannel = 3;
+    };
+
+    // Select the original broadcast channel in dropdown
     for "_index" from 0 to ((lbSize _channelCtrl) -1) do {
         private _channelID = _channelCtrl lbValue _index;
         if (_channelID isEqualTo _broadcastChannel) exitWith {

--- a/addons/markers/functions/fnc_isValidBroadcastChannel.sqf
+++ b/addons/markers/functions/fnc_isValidBroadcastChannel.sqf
@@ -16,6 +16,6 @@
  *
  */
 
-params [["_broadcastChannel", -2, [0]]];
+params [["_broadcastChannel", BC_INVALID, [0]]];
 
-_broadcastChannel <= 5 && {_broadcastChannel >= -1 || _broadcastChannel isEqualTo -10}
+_broadcastChannel <= 5 && {_broadcastChannel >= BC_SCRIPTED_LOCAL || _broadcastChannel isEqualTo BC_SCRIPTED_GLOBAL}

--- a/addons/markers/functions/fnc_isValidBroadcastChannel.sqf
+++ b/addons/markers/functions/fnc_isValidBroadcastChannel.sqf
@@ -1,0 +1,21 @@
+#include "script_component.hpp"
+/**
+ *  Author: Timi007
+ *
+ *  Description:
+ *      Check if given channel is a supported broadcast channel.
+ *
+ *  Parameter(s):
+ *      0: NUMBER - Broadcast channel.
+ *
+ *  Returns:
+ *      BOOLEAN - True if valid/supported; otherwise false.
+ *
+ *  Example:
+ *      [-10] call mts_markers_fnc_isValidBroadcastChannel
+ *
+ */
+
+params [["_broadcastChannel", -2, [0]]];
+
+_broadcastChannel <= 5 && {_broadcastChannel >= -1 || _broadcastChannel isEqualTo -10}

--- a/addons/markers/functions/fnc_setMarkerAlpha.sqf
+++ b/addons/markers/functions/fnc_setMarkerAlpha.sqf
@@ -25,7 +25,7 @@ CHECKRET(_namePrefix isEqualTo "",ERROR("No marker prefix"));
 // Get channel ID from marker prefix
 private _broadcastChannel = [_namePrefix] call FUNC(getBroadcastChannel);
 
-CHECKRET(((_broadcastChannel > 5) || (_broadcastChannel < -1)),ERROR("Invalid marker prefix. No MTS marker"));
+CHECKRET(!([_broadcastChannel] call FUNC(isValidBroadcastChannel)),ERROR("Invalid marker prefix. No MTS marker"));
 
 // Broadcast marker depending on channel ID
 [_namePrefix, _alpha] remoteExecCall [QFUNC(setMarkerAlphaLocal), ([_broadcastChannel] call FUNC(getBroadcastTargets)), true];

--- a/addons/markers/functions/fnc_setMarkerPos.sqf
+++ b/addons/markers/functions/fnc_setMarkerPos.sqf
@@ -24,7 +24,7 @@ CHECKRET(_namePrefix isEqualTo "",ERROR("No marker prefix"));
 //get channel ID from marker prefix
 private _broadcastChannel = [_namePrefix] call FUNC(getBroadcastChannel);
 
-CHECKRET(((_broadcastChannel > 5) || (_broadcastChannel < -1)),ERROR("Invalid marker prefix. No MTS marker"));
+CHECKRET(!([_broadcastChannel] call FUNC(isValidBroadcastChannel)),ERROR("Invalid marker prefix. No MTS marker"));
 
 //broadcast marker depending on channel ID
 [_namePrefix, _newPos] remoteExecCall [QFUNC(setMarkerPosLocal), ([_broadcastChannel] call FUNC(getBroadcastTargets)), true];

--- a/addons/markers/functions/fnc_setMarkerScale.sqf
+++ b/addons/markers/functions/fnc_setMarkerScale.sqf
@@ -24,7 +24,7 @@ CHECKRET(_namePrefix isEqualTo "",ERROR("No marker prefix"));
 //get channel ID from marker prefix
 private _broadcastChannel = [_namePrefix] call FUNC(getBroadcastChannel);
 
-CHECKRET(((_broadcastChannel > 5) || (_broadcastChannel < -1)),ERROR("Invalid marker prefix. No MTS marker"));
+CHECKRET(!([_broadcastChannel] call FUNC(isValidBroadcastChannel)),ERROR("Invalid marker prefix. No MTS marker"));
 
 //broadcast marker depending on channel ID
 [_namePrefix, _newScale] remoteExecCall [QFUNC(setMarkerScaleLocal), ([_broadcastChannel] call FUNC(getBroadcastTargets)), true];

--- a/addons/markers/functions/fnc_transmitUIData.sqf
+++ b/addons/markers/functions/fnc_transmitUIData.sqf
@@ -60,8 +60,8 @@ if (_isForMarkerCreation) then {
         if (is3DEN) exitWith {
             0
         };
-        if !(isMultiplayer) exitWith {
-            -1
+        if (!isMultiplayer) exitWith {
+            BC_SCRIPTED_LOCAL
         };
         private _channelCtrl = _mainDisplay displayCtrl CHANNEL_DROPDOWN;
         _channelCtrl lbValue (lbCurSel _channelCtrl)

--- a/addons/markers/script_component.hpp
+++ b/addons/markers/script_component.hpp
@@ -68,3 +68,9 @@
 // DTG
 #define MIN_YEAR 1900
 #define MAX_YEAR 2050
+
+// Special broadcast channels
+#define BC_SCRIPTED_LOCAL -1
+#define BC_INVALID -2
+#define BC_SCRIPTED_GLOBAL -10
+#define BC_SCRIPTED_GLOBAL_MARKER_SUFFIX "-1g"


### PR DESCRIPTION
**When merged this pull request will:**
- Add broadcast channel for scripted global marker that do not change transparency when switching chat channels.
- Set default fallback channel to group when editing special scripted marker in MP
